### PR TITLE
Feature/generatecerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,29 @@
                                 </mapping>
                             </mappings>
                             <preinstallScriptlet>
-                                <script>echo "installing now"</script>
+                                <script>
+echo "installing now"
+# First, get the IP of the host; try external with a timeout
+ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
+if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
+  ip=$(hostname -i)
+fi
+if echo $ip |grep  ^127 >/dev/null; then
+  defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
+  ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
+fi
+
+# Now, generate a certificate if it isn't already in /etc
+if [ ! -f /etc/keystorejetty ] ; then
+  keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
+  chmod 640 /etc/keystorejetty
+fi
+# To see the certificate:
+# keytool -list -storepass password -keystore /etc/keystorejetty  -rfc |openssl x509 -text
+
+#OBF of password is OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+
+                                </script>
                             </preinstallScriptlet>
                             <postinstallScriptlet>
                                 <script>echo "installed in /opt/fiware-paas"</script>

--- a/pom.xml
+++ b/pom.xml
@@ -477,20 +477,22 @@
                             <preinstallScriptlet>
                                 <script>
 echo "installing now"
-# First, get the IP of the host; try external with a timeout
-ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
-if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
-  ip=$(hostname -i)
-fi
-if echo $ip |grep  ^127 >/dev/null; then
-  defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
-  ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
-fi
-
-# Now, generate a certificate if it isn't already in /etc
+# Generate a certificate if it isn't already in /etc/keystorejetty
 if [ ! -f /etc/keystorejetty ] ; then
+  # Get the IP of the host; first try external with a timeout of 15s
+  ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
+  if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
+    ip=$(hostname -i)
+  fi
+  if echo $ip |grep  ^127 >/dev/null; then
+     defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
+     ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
+  fi
+
+  echo "Generating key and certificate with CN=$ip"
   keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
   chmod 640 /etc/keystorejetty
+  echo "Done"
 fi
 # To see the certificate:
 # keytool -list -storepass password -keystore /etc/keystorejetty  -rfc |openssl x509 -text

--- a/src/assembly/jetty/bin/generateselfsigned.sh
+++ b/src/assembly/jetty/bin/generateselfsigned.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+if [ $# -eq 1 ] ; then
+  ip=$1
+else
+  ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
+  if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
+     ip=$(hostname -i)
+  fi
+  if echo $ip |grep  ^127 >/dev/null ; then
+     defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
+     ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
+  fi
+fi
+echo "sigue"
+keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty.new -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
+
+if [ -f /etc/keystorejetty.new ] ; then
+   mv /etc/keystorejetty.new /etc/keystorejetty
+   echo "key and certificate generated in /etc/keystorejetty"
+fi
+

--- a/src/assembly/jetty/bin/generateselfsigned.sh
+++ b/src/assembly/jetty/bin/generateselfsigned.sh
@@ -11,7 +11,7 @@ else
      ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
   fi
 fi
-echo "sigue"
+echo "Generating certificate with CN=$ip"
 keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty.new -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
 
 if [ -f /etc/keystorejetty.new ] ; then

--- a/src/assembly/jetty/bin/importcert.sh
+++ b/src/assembly/jetty/bin/importcert.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# $1: key
+# $2: cert
+# $3: chain
+if [ $# -ne 3 ] ; then
+  echo "Use $0 <keyfile> <certfile> <chainfile>"
+  exit
+fi
+exit
+cat $2 $3 > fullchain.crt
+openssl pkcs12 -inkey $1 -in fullchain.crt -export -out jetty.pkcs12
+keytool -importkeystore -srckeystore jetty.pkcs12 -srcstoretype PKCS12 -destkeystore /etc/keystorejetty -srcstorepass password -deststorepass password -destalias jetty -alias 1
+chmod 640 /etc/keystorejetty
+rm fullchain.crt jetty.pkcs12

--- a/src/assembly/jetty/bin/importcert.sh
+++ b/src/assembly/jetty/bin/importcert.sh
@@ -6,9 +6,12 @@ if [ $# -ne 3 ] ; then
   echo "Use $0 <keyfile> <certfile> <chainfile>"
   exit
 fi
-exit
 cat $2 $3 > fullchain.crt
-openssl pkcs12 -inkey $1 -in fullchain.crt -export -out jetty.pkcs12
-keytool -importkeystore -srckeystore jetty.pkcs12 -srcstoretype PKCS12 -destkeystore /etc/keystorejetty -srcstorepass password -deststorepass password -destalias jetty -alias 1
+openssl pkcs12 -inkey $1 -in fullchain.crt -export -out jetty.pkcs12 -password pass:password
+keytool -importkeystore -srckeystore jetty.pkcs12 -srcstoretype PKCS12 -destkeystore /etc/keystorejetty.new -srcstorepass password -deststorepass password -destalias jetty -alias 1
 chmod 640 /etc/keystorejetty
 rm fullchain.crt jetty.pkcs12
+if [ -f /etc/keystorejetty.new ] ; then
+   mv /etc/keystorejetty.new /etc/keystorejetty
+   echo "content imported into /etc/keystorejetty"
+fi

--- a/src/assembly/jetty/etc/jetty-ssl.xml
+++ b/src/assembly/jetty/etc/jetty-ssl.xml
@@ -7,7 +7,7 @@
 <!-- and either jetty-https.xml or jetty-spdy.xml (but not both)   -->
 <!-- ============================================================= -->
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
-    <Set name="KeyStorePath"><Property name="jetty.base" default="."/>/
+    <Set name="KeyStorePath">
         <Property name="jetty.keystore" default="etc/keystore"/>
     </Set>
     <Set name="KeyStorePassword">
@@ -16,7 +16,7 @@
     <Set name="KeyManagerPassword">
         <Property name="jetty.keymanager.password" default="OBF:1u2u1wml1z7s1z7a1wnl1u2g"/>
     </Set>
-    <Set name="TrustStorePath"><Property name="jetty.base" default="."/>/
+    <Set name="TrustStorePath">
         <Property name="jetty.truststore" default="etc/keystore"/>
     </Set>
     <Set name="TrustStorePassword">

--- a/src/assembly/jetty/start.d/ssl.ini
+++ b/src/assembly/jetty/start.d/ssl.ini
@@ -7,15 +7,15 @@
 jetty.secure.port=8443
 
 # Setup a demonstration keystore and truststore
-jetty.keystore=etc/keystore
-jetty.truststore=etc/keystore
+jetty.keystore=/etc/keystorejetty
+jetty.truststore=/etc/keystorejetty
 
 # Set the demonstration passwords.
 # Note that OBF passwords are not secure, just protected from casual observation
 # See http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html
-jetty.keystore.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
-jetty.keymanager.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
-jetty.truststore.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
+jetty.keystore.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+jetty.keymanager.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+jetty.truststore.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
 
 # Set the client auth behavior
 # Set to true if client certificate authentication is required


### PR DESCRIPTION
 #### Reviewers
 @jesuspg  @hmunfru  

 #### Description
Create a keystore as /etc/keystorejetty, but only if this file does not exists.

The certificate is auto-signed.

The CN of the certificate is obtained according this algorithm:
-Check external IP using : /usr/bin/curl -m15 -s http://ifconfig.me/ip (there is a timeout of 15s)
-If this commands doesn't get a valid IP, try to obtain a IP with hostname -i
-If this command returns 127.0.0.1, get the IP of the interface where is the default route

Also a pair of new scripts are provided:
-A script to generate the keystore: if no parameter is provided, use the algorithm described, otherwise use the parameter received as CN.
-A script to create a keystore from a keyfile, cert, and certchain. This is useful to import a wildcart cert from an Apache host.

The other changes are in the configuration:
-Use /etc/keystorejetty instead of a file inside /opt/fiware-paas
-Use "password" as password.
 
#### Testing
 Locally. I've tested only that the package installs without errors, that server starts and that the generated certificate is used.